### PR TITLE
Allow external replacement of logger

### DIFF
--- a/engin.go
+++ b/engin.go
@@ -123,6 +123,10 @@ func (c *Engin) GetLogger() ILogger {
 	return c.logger
 }
 
+func (c *Engin) SetLogger(logger ILogger) {
+	c.logger = logger
+}
+
 func (c *Engin) bootSingle(conf *Config) error {
 	// 如果传入的是单一配置, 则转换成集群配置, 方便统一管理
 	var cc = new(ConfigCluster)


### PR DESCRIPTION
目前engine的logger对外不可见

```
func Logger() func(e *Engin) {
	return func(e *Engin) {
		e.logger = NewLogger(&LogOption{EnableSlowLog: 3})
	}
}
```
上述代码目前在非当前包下不可用

即使我写了闭包进行替换也只能初始化库自带的logger配置不同的参数
