### PR TITLE
fix：update buildsql去除字段别名

### DIFF
--- a/builder_default.go
+++ b/builder_default.go
@@ -291,6 +291,11 @@ func (b *BuilderDefault) parseData(operType string, data []map[string]interface{
 			}
 			//insertValues = append(insertValues, "("+strings.Join(insertValuesSub, ",")+")")
 			// update
+			// struct字段存在别名时，去掉别名
+			keySplits := strings.Split(key, ".")
+			if len(keySplits) == 2 {
+				key = keySplits[1]
+			}
 			dataObj = append(dataObj, fmt.Sprintf("%s = %s", b.current.AddFieldQuotes(key), placeholder))
 		}
 		insertValues = append(insertValues, "("+strings.Join(insertValuesSub, ",")+")")


### PR DESCRIPTION
update 数据时，struct 里 gorose tag包含表别名会导致插入错误，此段代码取 key 中的字段名称